### PR TITLE
Fix Darwin (Mac OS X) implementations of free disk check and backup media lookup

### DIFF
--- a/src/naksu/mebroutines/getdiskfree_darwin.go
+++ b/src/naksu/mebroutines/getdiskfree_darwin.go
@@ -8,7 +8,7 @@ import (
 
 // GetDiskFree returns disk space usage as float
 func GetDiskFree(path string) (int, error) {
-	runParams := []string{"df", "--output=avail", path}
+	runParams := []string{"df", path}
 
 	output, err := RunAndGetOutput(runParams)
 
@@ -16,8 +16,8 @@ func GetDiskFree(path string) (int, error) {
 		return -1, err
 	}
 
-	// Extract server disk image path
-	pattern := regexp.MustCompile("(\\d+)")
+	// Extract server disk image path using tail-hooked regexp
+	pattern := regexp.MustCompile(`([0-9]+)\s+[0-9]+%\s+[0-9]+\s+[0-9]+\s+[0-9]+%\s+[a-zA-Z0-9/]+$`)
 	result := pattern.FindStringSubmatch(output)
 
 	if len(result) > 1 {


### PR DESCRIPTION
These changes are done to make local development easier on Mac.

Backup media lookup does not scan for USB devices on Mac, since there are no trivial way to implement it.