### PR TITLE
Disable self update with config and introduce command line parameters using go-flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ windows: naksu.exe
 
 linux: naksu
 
+mac: naksu-darwin
+
 src/naksu.syso: res/windows/*
 	$(RSRC) -arch="amd64" -ico="res/windows/naksu.ico" -o src/naksu.syso
 
@@ -52,6 +54,9 @@ naksu.exe: src/*
 
 naksu: src/*
 	GOPATH=$(current_dir)/ GOOS=linux GOARCH=amd64 CGO_ENABLED=1 $(GO) build -o bin/naksu naksu
+
+naksu-darwin: src/*
+	GOPATH=$(current_dir)/ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 $(GO) build -o bin/naksu-darwin naksu
 
 naksu_packages: all
 	rm -f naksu_linux_amd64.zip

--- a/src/naksu/Gopkg.lock
+++ b/src/naksu/Gopkg.lock
@@ -26,6 +26,22 @@
   version = "v3.5.1"
 
 [[projects]]
+  digest = "1:6f9339c912bbdda81302633ad7e99a28dfa5a639c864061f1929510a9a64aa74"
+  name = "github.com/dustin/go-humanize"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9f541cc9db5d55bce703bd99987c9d5cb8eea45e"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:15e27372d379b45b18ac917b9dafc45c45485239490ece18cca97a12f9591146"
+  name = "github.com/go-ini/ini"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9c8236e659b76e87bf02044d06fde8683008ff3e"
+  version = "v1.39.0"
+
+[[projects]]
   digest = "1:64a5a67c69b70c2420e607a8545d674a23778ed9c3e80607bfd17b77c6c87f6a"
   name = "github.com/go-ole/go-ole"
   packages = [
@@ -154,6 +170,8 @@
     "github.com/StackExchange/wmi",
     "github.com/andlabs/ui",
     "github.com/blang/semver",
+    "github.com/dustin/go-humanize",
+    "github.com/go-ini/ini",
     "github.com/kardianos/osext",
     "github.com/rhysd/go-github-selfupdate/selfupdate",
   ]

--- a/src/naksu/Gopkg.lock
+++ b/src/naksu/Gopkg.lock
@@ -90,6 +90,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:4bb169ce06341a7c5e6c9a6734b25c606f59e2f765703301f92d159cf999672e"
+  name = "github.com/jessevdk/go-flags"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5de817a9aa209ed35a164cb04aec82b7df1a47a6"
+
+[[projects]]
+  branch = "master"
   digest = "1:caf6db28595425c0e0f2301a00257d11712f65c1878e12cffc42f6b9a9cf3f23"
   name = "github.com/kardianos/osext"
   packages = ["."]
@@ -172,6 +180,7 @@
     "github.com/blang/semver",
     "github.com/dustin/go-humanize",
     "github.com/go-ini/ini",
+    "github.com/jessevdk/go-flags",
     "github.com/kardianos/osext",
     "github.com/rhysd/go-github-selfupdate/selfupdate",
   ]

--- a/src/naksu/Gopkg.toml
+++ b/src/naksu/Gopkg.toml
@@ -53,6 +53,10 @@
   name = "github.com/go-ini/ini"
   version = "1.39.0"
   
+[[constraint]]
+  name = "github.com/jessevdk/go-flags"
+  branch = "master"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/src/naksu/Gopkg.toml
+++ b/src/naksu/Gopkg.toml
@@ -48,6 +48,10 @@
 [[constraint]]
   name = "github.com/dustin/go-humanize"
   version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/go-ini/ini"
+  version = "1.39.0"
   
 [prune]
   go-tests = true

--- a/src/naksu/config/config.go
+++ b/src/naksu/config/config.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"fmt"
+	"naksu/mebroutines"
+	"strconv"
+
+	"github.com/go-ini/ini"
+)
+
+var cfg *ini.File
+
+func setIfMissing(section string, key string, defaultValue string) {
+	if !cfg.Section(section).HasKey(key) {
+		cfg.Section(section).Key(key).SetValue(defaultValue)
+	}
+}
+
+type defaultValue struct {
+	section, key, value string
+}
+
+var defaults []defaultValue
+
+func initDefaults() {
+	defaults = []defaultValue{
+		defaultValue{"common", "iniVersion", strconv.FormatInt(1, 10)},
+		defaultValue{"common", "language", "fi"},
+		defaultValue{"selfupdate", "disabled", strconv.FormatBool(false)},
+		defaultValue{"selfupdate", "useBeta", strconv.FormatBool(false)},
+	}
+}
+
+func fillDefaults() {
+	for _, defaultValue := range defaults {
+		setIfMissing(defaultValue.section, defaultValue.key, defaultValue.value)
+	}
+}
+
+func getBoolean(section string, key string) bool {
+	value, err := getValue("selfupdate", "disabled").Bool()
+	if err != nil {
+		mebroutines.LogDebug(fmt.Sprintf("Parsing key %s / %s as bool failed", section, key))
+		panic(fmt.Sprintf("Invalid boolean configuration flag! section: %s, key: %s", section, key))
+	}
+	return value
+}
+
+func getValue(section string, key string) *ini.Key {
+	return cfg.Section(section).Key(key)
+}
+
+func setValue(section string, key string, value string) {
+	cfg.Section(section).Key(key).SetValue(value)
+}
+
+// Load or initialize configuration to empty object
+func Load() {
+	initDefaults()
+	var err error
+	cfg, err = ini.Load("naksu.ini")
+	if err != nil {
+		mebroutines.LogDebug("naksu.ini not found, setting up empty config with defaults")
+		cfg = ini.Empty()
+	}
+	fillDefaults()
+}
+
+// Save configuration to disk
+func Save() {
+	cfg.SaveTo("naksu.ini")
+}
+
+// GetLanguage returns user language preference. defaults to fi
+func GetLanguage() string {
+	return getValue("common", "language").String()
+}
+
+// SetLanguage stores user language preference
+func SetLanguage(language string) {
+	setValue("common", "language", language)
+}
+
+// IsSelfUpdateDisabled returns true, if self-update functionality should be disabled
+func IsSelfUpdateDisabled() bool {
+	return getBoolean("selfupdate", "disabled")
+}
+
+// SetReleaseChannel sets the release channel to selected value. Default is "release"
+func SetReleaseChannel(channel string) {
+	setValue("selfupdate", "channel", channel)
+}
+
+// GetReleaseChannel returns selected release channel. Default is "release"
+func GetReleaseChannel() string {
+	return getValue("selfupdate", "channel").String()
+}

--- a/src/naksu/config/config.go
+++ b/src/naksu/config/config.go
@@ -69,14 +69,32 @@ func save() {
 	}
 }
 
+var languages = map[string]bool{
+	"en": true,
+	"fi": true,
+	"sv": true,
+}
+
 // GetLanguage returns user language preference. defaults to fi
 func GetLanguage() string {
-	return getValue("common", "language").String()
+	value := getValue("common", "language").String()
+	_, ok := languages[value]
+	if ok {
+		return value
+	} else {
+		setValue("common", "language", "fi")
+		return "fi"
+	}
 }
 
 // SetLanguage stores user language preference
 func SetLanguage(language string) {
-	setValue("common", "language", language)
+	_, ok := languages[language]
+	if ok {
+		setValue("common", "language", language)
+	} else {
+		setValue("common", "language", "fi")
+	}
 }
 
 // IsSelfUpdateDisabled returns true, if self-update functionality should be disabled

--- a/src/naksu/config/config.go
+++ b/src/naksu/config/config.go
@@ -63,7 +63,10 @@ func Load() {
 
 // Save configuration to disk
 func save() {
-	cfg.SaveTo("naksu.ini")
+	err := cfg.SaveTo("naksu.ini")
+	if err != nil {
+		mebroutines.LogDebug(fmt.Sprintf("naksu.ini save failed: %v", err))
+	}
 }
 
 // GetLanguage returns user language preference. defaults to fi

--- a/src/naksu/config/config.go
+++ b/src/naksu/config/config.go
@@ -27,7 +27,6 @@ func initDefaults() {
 		defaultValue{"common", "iniVersion", strconv.FormatInt(1, 10)},
 		defaultValue{"common", "language", "fi"},
 		defaultValue{"selfupdate", "disabled", strconv.FormatBool(false)},
-		defaultValue{"selfupdate", "useBeta", strconv.FormatBool(false)},
 	}
 }
 
@@ -86,12 +85,7 @@ func IsSelfUpdateDisabled() bool {
 	return getBoolean("selfupdate", "disabled")
 }
 
-// SetReleaseChannel sets the release channel to selected value. Default is "release"
-func SetReleaseChannel(channel string) {
-	setValue("selfupdate", "channel", channel)
-}
-
-// GetReleaseChannel returns selected release channel. Default is "release"
-func GetReleaseChannel() string {
-	return getValue("selfupdate", "channel").String()
+// SetSelfUpdateDisabled sets the state of self-update functionality
+func SetSelfUpdateDisabled(isSelfUpdateDisabled bool) {
+	setValue("selfupdate", "disabled", strconv.FormatBool(isSelfUpdateDisabled))
 }

--- a/src/naksu/config/config.go
+++ b/src/naksu/config/config.go
@@ -32,7 +32,7 @@ func fillDefaults() {
 }
 
 func getBoolean(section string, key string) bool {
-	value, err := getValue("selfupdate", "disabled").Bool()
+	value, err := getValue(section, key).Bool()
 	if err != nil {
 		mebroutines.LogDebug(fmt.Sprintf("Parsing key %s / %s as bool failed", section, key))
 		panic(fmt.Sprintf("Invalid boolean configuration flag! section: %s, key: %s", section, key))

--- a/src/naksu/config/config.go
+++ b/src/naksu/config/config.go
@@ -20,17 +20,12 @@ type defaultValue struct {
 	section, key, value string
 }
 
-var defaults []defaultValue
-
-func initDefaults() {
-	defaults = []defaultValue{
+func fillDefaults() {
+	defaults := []defaultValue{
 		defaultValue{"common", "iniVersion", strconv.FormatInt(1, 10)},
 		defaultValue{"common", "language", "fi"},
 		defaultValue{"selfupdate", "disabled", strconv.FormatBool(false)},
 	}
-}
-
-func fillDefaults() {
 	for _, defaultValue := range defaults {
 		setIfMissing(defaultValue.section, defaultValue.key, defaultValue.value)
 	}
@@ -51,11 +46,11 @@ func getValue(section string, key string) *ini.Key {
 
 func setValue(section string, key string, value string) {
 	cfg.Section(section).Key(key).SetValue(value)
+	save()
 }
 
 // Load or initialize configuration to empty object
 func Load() {
-	initDefaults()
 	var err error
 	cfg, err = ini.Load("naksu.ini")
 	if err != nil {
@@ -63,10 +58,11 @@ func Load() {
 		cfg = ini.Empty()
 	}
 	fillDefaults()
+	save()
 }
 
 // Save configuration to disk
-func Save() {
+func save() {
 	cfg.SaveTo("naksu.ini")
 }
 

--- a/src/naksu/naksu.go
+++ b/src/naksu/naksu.go
@@ -17,6 +17,8 @@ const lowDiskLimit = 50 * 1024 * 1024 // 50 Gb
 var isDebug bool
 
 func main() {
+	// Load configuration if it exists
+	config.Load()
 	// Set default UI language
 	xlate.SetLanguage("fi")
 
@@ -57,6 +59,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	config.Save()
 
 	mebroutines.LogDebug("Exiting GUI loop")
 }

--- a/src/naksu/naksu.go
+++ b/src/naksu/naksu.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
+	"naksu/config"
 	"naksu/mebroutines"
 	"naksu/xlate"
 	"os"
 	"strings"
 
+	"github.com/jessevdk/go-flags"
 	"github.com/kardianos/osext"
 )
 
@@ -16,16 +17,56 @@ const lowDiskLimit = 50 * 1024 * 1024 // 50 Gb
 
 var isDebug bool
 
+// Options contains command line options
+type Options struct {
+	IsDebug    bool   `short:"D" long:"debug" description:"Turn debugging on" optional:"true"`
+	Version    bool   `short:"v" long:"version" description:"Print naksu version" optional:"true"`
+	SelfUpdate string `long:"self-update" choice:"enabled" choice:"disabled" description:"Control self-update behaviour. Naksu will always warn if your version is out-of-date" optional:"true"`
+}
+
+var options Options
+
+func handleOptionalArgument(longName string, parser *flags.Parser, function func(option *flags.Option)) {
+	opt := parser.FindOptionByLongName(longName)
+	if opt != nil && opt.IsSet() {
+		function(opt)
+	}
+}
+
 func main() {
 	// Load configuration if it exists
 	config.Load()
+
 	// Set default UI language
 	xlate.SetLanguage(config.GetLanguage())
 
+	var parser = flags.NewParser(&options, flags.Default)
+	_, parseErr := parser.Parse()
 
-	// Process command line parameters
-	flag.BoolVar(&isDebug, "debug", false, "Turn debugging on")
-	flag.Parse()
+	if flags.WroteHelp(parseErr) {
+		os.Exit(0)
+	} else if parseErr != nil {
+		panic(parseErr)
+	}
+
+	handleOptionalArgument("debug", parser, func(opt *flags.Option) {
+		isDebug = true
+	})
+
+	handleOptionalArgument("version", parser, func(opt *flags.Option) {
+		fmt.Printf("Naksu version is %v\n", version)
+		os.Exit(0)
+	})
+
+	handleOptionalArgument("self-update", parser, func(opt *flags.Option) {
+		mebroutines.LogDebug(fmt.Sprintf("Self-update: %v", opt.Value()))
+		if opt.Value() == "disabled" {
+			config.SetSelfUpdateDisabled(true)
+		} else {
+			config.SetSelfUpdateDisabled(false)
+		}
+		config.Save()
+	})
 
 	RunSelfUpdate()
 

--- a/src/naksu/naksu.go
+++ b/src/naksu/naksu.go
@@ -21,7 +21,7 @@ var isDebug bool
 type Options struct {
 	IsDebug    bool   `short:"D" long:"debug" description:"Turn debugging on" optional:"true"`
 	Version    bool   `short:"v" long:"version" description:"Print naksu version" optional:"true"`
-	SelfUpdate string `long:"self-update" choice:"enabled" choice:"disabled" description:"Control self-update behaviour. Naksu will always warn if your version is out-of-date" optional:"true"`
+	SelfUpdate string `long:"self-update" choice:"enabled" choice:"disabled" description:"Control self-update behaviour. Naksu will always warn if your version is out-of-date. This flag will store the setting to ini-file." optional:"true"`
 }
 
 var options Options

--- a/src/naksu/naksu.go
+++ b/src/naksu/naksu.go
@@ -20,7 +20,8 @@ func main() {
 	// Load configuration if it exists
 	config.Load()
 	// Set default UI language
-	xlate.SetLanguage("fi")
+	xlate.SetLanguage(config.GetLanguage())
+
 
 	// Process command line parameters
 	flag.BoolVar(&isDebug, "debug", false, "Turn debugging on")

--- a/src/naksu/naksu.go
+++ b/src/naksu/naksu.go
@@ -65,7 +65,6 @@ func main() {
 		} else {
 			config.SetSelfUpdateDisabled(false)
 		}
-		config.Save()
 	})
 
 	RunSelfUpdate()
@@ -101,8 +100,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
-	config.Save()
 
 	mebroutines.LogDebug("Exiting GUI loop")
 }

--- a/src/naksu/selfupdate.go
+++ b/src/naksu/selfupdate.go
@@ -5,25 +5,31 @@ package main
 
 import (
 	"fmt"
+	"naksu/config"
 	"naksu/mebroutines"
-	"naksu/xlate"
 	"naksu/network"
+	"naksu/xlate"
 	"os"
 
 	"github.com/blang/semver"
 	"github.com/rhysd/go-github-selfupdate/selfupdate"
 )
 
+var isOutOfDate bool
+
 // RunSelfUpdate executes self-update
 func RunSelfUpdate() {
 	// Run auto-update
-	if doSelfUpdate() {
+	if doReleaseSelfUpdate() {
 		mebroutines.ShowWarningMessage("naksu has been automatically updated. Please restart naksu.")
 		os.Exit(0)
 	}
+	if WarnUserAboutStaleVersionIfUpdateDisabled() {
+		mebroutines.ShowWarningMessage("naksu has update available, but your version of naksu has updates disabled. please update or ask your administrator to update naksu")
+	}
 }
 
-func doSelfUpdate() bool {
+func doReleaseSelfUpdate() bool {
 	v := semver.MustParse(version)
 
 	if mebroutines.IsDebug() {
@@ -33,6 +39,19 @@ func doSelfUpdate() bool {
 	// Test network connection here with a timeout
 	if !network.CheckIfNetworkAvailable() {
 		mebroutines.ShowWarningMessage(xlate.Get("Naksu could not check for updates as there is no network connection."))
+		return false
+	}
+
+	// If self-update is disabled, do a version check nevertheless and store information for user warning
+	if config.IsSelfUpdateDisabled() {
+		latest, found, err := selfupdate.DetectLatest("digabi/naksu")
+		if err != nil {
+			mebroutines.LogDebug(fmt.Sprintf("Version check failed: %s", err))
+			return false
+		}
+		if found && latest.Version.GT(v) {
+			isOutOfDate = true
+		}
 		return false
 	}
 
@@ -49,4 +68,10 @@ func doSelfUpdate() bool {
 	mebroutines.LogDebug(fmt.Sprintf("Successfully updated to version: %s", latest.Version))
 	return true
 	//log.Println("Release note:\n", latest.ReleaseNotes)
+}
+
+// WarnUserAboutStaleVersionIfUpdateDisabled tells us if we should warn user that they are running old version if self-update is disabled. This is very corner-case check
+// for environments that prefer distributing naksu via AD or other centralized management environment
+func WarnUserAboutStaleVersionIfUpdateDisabled() bool {
+	return config.IsSelfUpdateDisabled() && isOutOfDate
 }

--- a/src/naksu/ui.go
+++ b/src/naksu/ui.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"naksu/config"
 	"naksu/mebroutines"
 	"naksu/mebroutines/backup"
 	"naksu/mebroutines/install"
@@ -92,7 +93,14 @@ func createMainWindowElements() {
 	comboboxLang.Append("Suomeksi")
 	comboboxLang.Append("På svenska")
 	comboboxLang.Append("In English")
-	comboboxLang.SetSelected(0)
+	switch config.GetLanguage() {
+	case "fi":
+		comboboxLang.SetSelected(0)
+	case "sv":
+		comboboxLang.SetSelected(1)
+	case "en":
+		comboboxLang.SetSelected(1)
+	}
 
 	labelBox = ui.NewLabel("")
 	labelStatus = ui.NewLabel("")
@@ -360,13 +368,14 @@ func bindLanguageSwitching() {
 	comboboxLang.OnSelected(func(*ui.Combobox) {
 		switch comboboxLang.Selected() {
 		case 0:
-			xlate.SetLanguage("fi")
+			config.SetLanguage("fi")
 		case 1:
-			xlate.SetLanguage("sv")
+			config.SetLanguage("sv")
 		case 2:
-			xlate.SetLanguage("en")
+			config.SetLanguage("en")
 		}
 
+		xlate.SetLanguage(config.GetLanguage())
 		translateUILabels()
 	})
 }

--- a/src/naksu/ui.go
+++ b/src/naksu/ui.go
@@ -5,10 +5,10 @@ import (
 	"naksu/config"
 	"naksu/mebroutines"
 	"naksu/mebroutines/backup"
-	"naksu/mebroutines/install"
-	"naksu/mebroutines/start"
 	"naksu/mebroutines/destroy"
+	"naksu/mebroutines/install"
 	"naksu/mebroutines/remove"
+	"naksu/mebroutines/start"
 	"naksu/network"
 	"naksu/progress"
 	"naksu/xlate"
@@ -78,7 +78,6 @@ var removeBox *ui.Box
 
 var removeInfoLabel [5]*ui.Label
 
-
 func createMainWindowElements() {
 	// Define main window
 	buttonStartServer = ui.NewButton("Start Exam Server")
@@ -99,7 +98,9 @@ func createMainWindowElements() {
 	case "sv":
 		comboboxLang.SetSelected(1)
 	case "en":
-		comboboxLang.SetSelected(1)
+		comboboxLang.SetSelected(2)
+	default:
+		comboboxLang.SetSelected(0)
 	}
 
 	labelBox = ui.NewLabel("")
@@ -174,7 +175,7 @@ func createBackupElements(backupMedia map[string]string) {
 
 func createDestroyElements() {
 	// Define Destroy Confirmation window/dialog
-	for i:=0; i<=4; i++ {
+	for i := 0; i <= 4; i++ {
 		destroyInfoLabel[i] = ui.NewLabel("destroyInfoLabel")
 	}
 
@@ -183,7 +184,7 @@ func createDestroyElements() {
 
 	destroyBox = ui.NewVerticalBox()
 	destroyBox.SetPadded(true)
-	for i:=0; i<=4; i++ {
+	for i := 0; i <= 4; i++ {
 		destroyBox.Append(destroyInfoLabel[i], false)
 	}
 	destroyBox.Append(destroyButtonDestroy, false)
@@ -197,7 +198,7 @@ func createDestroyElements() {
 
 func createRemoveElements() {
 	// Define Destroy Confirmation window/dialog
-	for i:=0; i<=4; i++ {
+	for i := 0; i <= 4; i++ {
 		removeInfoLabel[i] = ui.NewLabel("removeInfoLabel")
 	}
 
@@ -206,7 +207,7 @@ func createRemoveElements() {
 
 	removeBox = ui.NewVerticalBox()
 	removeBox.SetPadded(true)
-	for i:=0; i<=4; i++ {
+	for i := 0; i <= 4; i++ {
 		removeBox.Append(removeInfoLabel[i], false)
 	}
 	removeBox.Append(removeButtonRemove, false)
@@ -373,6 +374,8 @@ func bindLanguageSwitching() {
 			config.SetLanguage("sv")
 		case 2:
 			config.SetLanguage("en")
+		default:
+			config.SetLanguage("fi")
 		}
 
 		xlate.SetLanguage(config.GetLanguage())
@@ -588,7 +591,7 @@ func bindOnDestroy(mainUIStatus chan string) {
 	// Define actions for Destroy window/dialog
 
 	destroyButtonDestroy.OnClicked(func(*ui.Button) {
-		go func () {
+		go func() {
 			destroyWindow.Hide()
 			destroy.Server()
 			progress.SetMessage("")
@@ -616,7 +619,7 @@ func bindOnRemove(mainUIStatus chan string) {
 	// Define actions for Remove window/dialog
 
 	removeButtonRemove.OnClicked(func(*ui.Button) {
-		go func () {
+		go func() {
 			removeWindow.Hide()
 
 			err := remove.Server()


### PR DESCRIPTION
Introduce ini-file support (experimental) for remembering settings via ini-file, and add proper command line parsing.

Ini-file handling has one unsolved issue still: currently ini-file is stored in same path as Naksu, and this may cause issues on some systems (if the path is write only).

This patch was meant to also include beta-channel support, but introducing pre-release support for used library was simply too time-consuming.

This feature should (thus) be considered as enabling feature for making other configuration features such as alternate NIC-environment variable handling easier.

This patch also includes Makefile build rule for Mac OS X in order to make local development easier.