### PR TITLE
Feature/show vb version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ci-test: bin/go2xunit
 	2>&1 GOPATH=$(current_dir)/ go test -v naksu/mebroutines naksu/boxversion | ./bin/go2xunit -output tests.xml
 
 test:
-	GOPATH=$(current_dir)/ go test naksu/mebroutines naksu/boxversion
+	GOPATH=$(current_dir)/ go test naksu/mebroutines naksu/box naksu/boxversion
 
 docker: clean
 	mkdir -p bin

--- a/src/naksu/box/box.go
+++ b/src/naksu/box/box.go
@@ -31,6 +31,10 @@ func getVagrantBoxID() string {
 
 	pathID := filepath.Join(vagrantPath, ".vagrant", "machines", "default", "virtualbox", "id")
 
+	if ! mebroutines.ExistsFile(pathID) {
+		return ""
+	}
+
 	/* #nosec */
 	fileContent, err := ioutil.ReadFile(pathID)
 	if err != nil {

--- a/src/naksu/box/box.go
+++ b/src/naksu/box/box.go
@@ -1,0 +1,92 @@
+package box
+
+// box gets information about the Vagrant box "default" directly from VirtualBox
+// This package gives most up-to-date information about the server box
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"naksu/constants"
+	"naksu/mebroutines"
+	"naksu/xlate"
+)
+
+// cache for VBoxMange showvminfo --machinereadable
+// See getVMInfoRegexp
+type cacheShowVMInfoType struct {
+	output    string
+	timestamp int64
+}
+
+var cacheShowVMInfo cacheShowVMInfoType
+
+func getVagrantBoxID() string {
+	vagrantPath := mebroutines.GetVagrantDirectory()
+
+	pathID := filepath.Join(vagrantPath, ".vagrant", "machines", "default", "virtualbox", "id")
+
+	/* #nosec */
+	fileContent, err := ioutil.ReadFile(pathID)
+	if err != nil {
+		mebroutines.ShowWarningMessage(fmt.Sprintf(xlate.Get("Could not get vagrantbox ID: %d"), err))
+		return ""
+	}
+
+	return string(fileContent)
+}
+
+// SetCacheShowVMInfo sets cacheShowVMInfo content
+// It is exported for unit tests
+func SetCacheShowVMInfo(newShowVMInfo string) {
+	cacheShowVMInfo.output = newShowVMInfo
+	cacheShowVMInfo.timestamp = time.Now().Unix()
+}
+
+func getVMInfoRegexp(vmRegexp string) string {
+	var vBoxManageOutput string
+
+	// Get showvminfo from cache/by executing VBoxManage
+	// Running VBoxManage showvminfo too often makes VBoxManage to exit with code 1:
+	//   VBoxManage: error: The object is not ready
+	//   VBoxManage: error: Details: code E_ACCESSDENIED (0x80070005), component SessionMachine, interface IMachine, callee nsISupports"
+	if cacheShowVMInfo.timestamp < (time.Now().Unix() - constants.VBoxManageCacheTimeout) {
+		boxID := getVagrantBoxID()
+		if boxID == "" {
+			return ""
+		}
+
+		vBoxManageOutput = mebroutines.RunVBoxManage([]string{"showvminfo", "--machinereadable", boxID})
+		SetCacheShowVMInfo(vBoxManageOutput)
+	} else {
+		vBoxManageOutput = cacheShowVMInfo.output
+	}
+
+	// Extract server name
+	pattern := regexp.MustCompile(vmRegexp)
+	result := pattern.FindStringSubmatch(vBoxManageOutput)
+
+	if len(result) > 1 {
+		return result[1]
+	}
+
+	return ""
+}
+
+// GetType returns the box type (e.g. "digabi/ktp-qa") of the current VM
+func GetType() string {
+	return getVMInfoRegexp("description=\"(.*?)\"")
+}
+
+// GetVersion returns the version string (e.g. "SERVER7108X v69") of the current VM
+func GetVersion() string {
+	return getVMInfoRegexp("name=\"(.*?)\"")
+}
+
+// GetDiskUUID returns the VirtualBox UUID for the image of the current VM
+func GetDiskUUID() string {
+	return getVMInfoRegexp("\"SATA Controller-ImageUUID-0-0\"=\"(.*?)\"")
+}

--- a/src/naksu/box/box_test.go
+++ b/src/naksu/box/box_test.go
@@ -1,0 +1,172 @@
+package box_test
+
+import (
+  "testing"
+  "naksu/box"
+)
+
+func TestGetEverything(t *testing.T) {
+  sampleShowVmInfoOutput1 := `
+  name="SERVER1919C v114"
+  groups="/"
+  ostype="Debian (32-bit)"
+  UUID="8c722e19-bd30-4eb3-b36a-95fc4e20c072"
+  CfgFile="/opt/matti/VirtualBox_VMs/SERVER1919C v114/SERVER1919C v114.vbox"
+  SnapFldr="/opt/matti/VirtualBox_VMs/SERVER1919C v114/Snapshots"
+  LogFldr="/opt/matti/VirtualBox_VMs/SERVER1919C v114/Logs"
+  hardwareuuid="8c722e19-bd30-4eb3-b36a-95fc4e20c072"
+  memory=11827
+  pagefusion="off"
+  vram=24
+  cpuexecutioncap=100
+  hpet="off"
+  chipset="piix3"
+  firmware="EFI"
+  cpus=7
+  pae="on"
+  longmode="on"
+  triplefaultreset="off"
+  apic="on"
+  x2apic="off"
+  cpuid-portability-level=0
+  bootmenu="messageandmenu"
+  boot1="floppy"
+  boot2="dvd"
+  boot3="disk"
+  boot4="none"
+  acpi="on"
+  ioapic="on"
+  biosapic="apic"
+  biossystemtimeoffset=0
+  rtcuseutc="on"
+  hwvirtex="on"
+  nestedpaging="on"
+  largepages="off"
+  vtxvpid="on"
+  vtxux="on"
+  paravirtprovider="default"
+  effparavirtprovider="kvm"
+  VMState="poweroff"
+  VMStateChangeTime="2019-05-10T11:44:23.874000000"
+  monitorcount=1
+  accelerate3d="off"
+  accelerate2dvideo="off"
+  teleporterenabled="off"
+  teleporterport=0
+  teleporteraddress=""
+  teleporterpassword=""
+  tracing-enabled="off"
+  tracing-allow-vm-access="off"
+  tracing-config=""
+  autostart-enabled="off"
+  autostart-delay=0
+  defaultfrontend=""
+  storagecontrollername0="SATA Controller"
+  storagecontrollertype0="IntelAhci"
+  storagecontrollerinstance0="0"
+  storagecontrollermaxportcount0="30"
+  storagecontrollerportcount0="30"
+  storagecontrollerbootable0="on"
+  "SATA Controller-0-0"="/opt/matti/VirtualBox_VMs/SERVER1919C v114/box-disk001.vmdk"
+  "SATA Controller-ImageUUID-0-0"="ced7cfb7-82cd-4f36-9e83-c933ba0e0220"
+  "SATA Controller-1-0"="none"
+  "SATA Controller-2-0"="none"
+  "SATA Controller-3-0"="none"
+  "SATA Controller-4-0"="none"
+  "SATA Controller-5-0"="none"
+  "SATA Controller-6-0"="none"
+  "SATA Controller-7-0"="none"
+  "SATA Controller-8-0"="none"
+  "SATA Controller-9-0"="none"
+  "SATA Controller-10-0"="none"
+  "SATA Controller-11-0"="none"
+  "SATA Controller-12-0"="none"
+  "SATA Controller-13-0"="none"
+  "SATA Controller-14-0"="none"
+  "SATA Controller-15-0"="none"
+  "SATA Controller-16-0"="none"
+  "SATA Controller-17-0"="none"
+  "SATA Controller-18-0"="none"
+  "SATA Controller-19-0"="none"
+  "SATA Controller-20-0"="none"
+  "SATA Controller-21-0"="none"
+  "SATA Controller-22-0"="none"
+  "SATA Controller-23-0"="none"
+  "SATA Controller-24-0"="none"
+  "SATA Controller-25-0"="none"
+  "SATA Controller-26-0"="none"
+  "SATA Controller-27-0"="none"
+  "SATA Controller-28-0"="none"
+  "SATA Controller-29-0"="none"
+  bridgeadapter1="em1"
+  macaddress1="0800271DE972"
+  cableconnected1="on"
+  nic1="bridged"
+  nictype1="virtio"
+  nicspeed1="0"
+  nic2="none"
+  nic3="none"
+  nic4="none"
+  nic5="none"
+  nic6="none"
+  nic7="none"
+  nic8="none"
+  hidpointing="ps2mouse"
+  hidkeyboard="ps2kbd"
+  uart1="off"
+  uart2="off"
+  uart3="off"
+  uart4="off"
+  lpt1="off"
+  lpt2="off"
+  audio="none"
+  audio_in="false"
+  audio_out="false"
+  clipboard="bidirectional"
+  draganddrop="disabled"
+  vrde="off"
+  usb="off"
+  ehci="off"
+  xhci="off"
+  SharedFolderNameMachineMapping1="media_usb1"
+  SharedFolderPathMachineMapping1="/home/matti/ktp-jako"
+  videocap="off"
+  videocap_audio="off"
+  videocapscreens=0
+  videocapfile="/opt/matti/VirtualBox_VMs/SERVER1919C v114/SERVER1919C v114.webm"
+  videocapres=1024x768
+  videocaprate=512
+  videocapfps=25
+  videocapopts=
+  description="digabi/ktp-qa"
+  GuestMemoryBalloon=0
+  `
+
+  tables := []struct {
+    showVmInfoOutput string
+    expectedType string
+    expectedVersion string
+    expectedDiskUUID string
+  }{
+    {sampleShowVmInfoOutput1, "digabi/ktp-qa", "SERVER1919C v114", "ced7cfb7-82cd-4f36-9e83-c933ba0e0220"},
+  }
+
+  for _, table := range tables {
+    box.SetCacheShowVMInfo(table.showVmInfoOutput)
+
+    observedType := box.GetType()
+    if observedType != table.expectedType {
+      t.Errorf("GetType() returns '%s' instead of expected '%s'", observedType, table.expectedType)
+    }
+
+    observedVersion := box.GetVersion()
+    if observedVersion != table.expectedVersion {
+      t.Errorf("GetVersion() returns '%s' instead of expected '%s'", observedVersion, table.expectedVersion)
+    }
+
+    observedDiskUUID := box.GetDiskUUID()
+    if observedDiskUUID != table.expectedDiskUUID {
+      t.Errorf("GetDiskUUID() returns '%s' instead of expected '%s'", observedDiskUUID, table.expectedDiskUUID)
+    }
+  }
+}

--- a/src/naksu/boxversion/boxversion.go
+++ b/src/naksu/boxversion/boxversion.go
@@ -107,7 +107,7 @@ func GetVagrantBoxAvailVersionDetails() (string, string, error) {
 	// There is a avail version fetch going on (break free after 240 loops)
 	tryCounter := 0
 	for vagrantBoxAvailVersionDetailsCache.updateStarted != 0 && tryCounter < 240 {
-		time.Sleep(500)
+		time.Sleep(500 * time.Millisecond)
 		tryCounter++
 	}
 

--- a/src/naksu/boxversion/boxversion.go
+++ b/src/naksu/boxversion/boxversion.go
@@ -31,6 +31,9 @@ var vagrantBoxAvailVersionDetailsCache lastBoxAvail
 
 // GetVagrantFileVersion returns a human-readable localised version string
 // for a given Vagrantfile (with "" defaults to ~/ktp/Vagrantfile)
+//
+// If you want to get the version of the current box consider using
+// box.GetVersion() instead
 func GetVagrantFileVersion(vagrantFilePath string) string {
 	if vagrantFilePath == "" {
 		vagrantFilePath = filepath.Join(mebroutines.GetVagrantDirectory(), "Vagrantfile")

--- a/src/naksu/boxversion/boxversion_test.go
+++ b/src/naksu/boxversion/boxversion_test.go
@@ -124,7 +124,7 @@ func TestGetVagrantFileVersionAbitti (t *testing.T) {
     config.vm.box = "digabi/ktp-qa"
     config.vm.box_url = "https://s3-eu-west-1.amazonaws.com/static.abitti.fi/usbimg/qa/vagrant/metadata.json"
     config.vm.provider :virtualbox do |vb|
-      vb.name = "Virtual KTP v57"
+      vb.name = "SERVER7108X v57"
       vb.gui = true
       vb.customize ["modifyvm", :id, "--ioapic", "on"]
       vb.customize ["modifyvm", :id, "--cpus", cpus]
@@ -173,7 +173,7 @@ func TestGetVagrantFileVersionAbitti (t *testing.T) {
     config.vm.box = "digabi/ktp-k2018-45489"
     config.vm.box_url = "https://s3-eu-west-1.amazonaws.com/static.abitti.fi/usbimg/k2018-45489/vagrant/metadata.json"
     config.vm.provider :virtualbox do |vb|
-      vb.name = "Virtual KTP v37"
+      vb.name = "SERVER7304M v37"
       vb.gui = true
       vb.customize ["modifyvm", :id, "--ioapic", "on"]
       vb.customize ["modifyvm", :id, "--cpus", cpus]
@@ -193,8 +193,8 @@ func TestGetVagrantFileVersionAbitti (t *testing.T) {
     vagrantfileContent string
     versionString string
   }{
-    {sampleAbittiVagrantFileContent, "Abitti server (v57)"},
-    {sampleMebVagrantFileContent, "Matric Exam server (v37)"},
+    {sampleAbittiVagrantFileContent, "Abitti server (SERVER7108X v57)"},
+    {sampleMebVagrantFileContent, "Matric Exam server (SERVER7304M v37)"},
   }
 
   for _, table := range tables {

--- a/src/naksu/boxversion/boxversion_test.go
+++ b/src/naksu/boxversion/boxversion_test.go
@@ -3,9 +3,6 @@ package boxversion_test
 import (
   "testing"
   "naksu/boxversion"
-
-  "os"
-  "io/ioutil"
 )
 
 func TestGetVagrantBoxType (t *testing.T) {
@@ -192,30 +189,27 @@ func TestGetVagrantFileVersionAbitti (t *testing.T) {
   tables := []struct {
     vagrantfileContent string
     versionString string
+    versionType string
+    humanReadableBoxType string
   }{
-    {sampleAbittiVagrantFileContent, "Abitti server (SERVER7108X v57)"},
-    {sampleMebVagrantFileContent, "Matric Exam server (SERVER7304M v37)"},
+    {sampleAbittiVagrantFileContent, "SERVER7108X v57", "digabi/ktp-qa", "Abitti server"},
+    {sampleMebVagrantFileContent, "SERVER7304M v37", "digabi/ktp-k2018-45489", "Matric Exam server"},
   }
 
   for _, table := range tables {
-    tmpfile, err := ioutil.TempFile("", "mebroutines_test_")
-    if err != nil {
-      t.Errorf("Could not open %s: %v", tmpfile.Name(), err)
-    }
-
-    defer os.Remove(tmpfile.Name())
-
-    if _, err := tmpfile.WriteString(table.vagrantfileContent); err != nil {
-  		t.Errorf("Could not write to %s: %v", tmpfile.Name(), err)
-  	}
-  	if err := tmpfile.Close(); err != nil {
-      t.Errorf("Could not close %s: %v", tmpfile.Name(), err)
-  	}
-
-    versionString := boxversion.GetVagrantFileVersion(tmpfile.Name())
+    versionType, versionString, _ := boxversion.GetVagrantVersionDetails(table.vagrantfileContent)
+    humanReadableBoxType := boxversion.GetVagrantBoxType(versionType)
 
     if versionString != table.versionString {
-      t.Errorf("GetVagrantFileVersion returns wrong version string \"%s\" instead of \"%s\"", versionString, table.versionString)
+      t.Errorf("GetVagrantVersionDetails returns wrong version string \"%s\" instead of \"%s\"", versionString, table.versionString)
+    }
+
+    if versionType != table.versionType {
+      t.Errorf("GetVagrantVersionDetails returns wrong type string \"%s\" instead of \"%s\"", versionType, table.versionType)
+    }
+
+    if humanReadableBoxType != table.humanReadableBoxType {
+      t.Errorf("GetVagrantBoxType return wrong result \"%s\" instead of \"%s\" when called with parameter \"%s\"", humanReadableBoxType, table.humanReadableBoxType, versionType)
     }
   }
 }

--- a/src/naksu/constants/constants.go
+++ b/src/naksu/constants/constants.go
@@ -18,6 +18,10 @@ const (
 	// cache. See naksu/boxversion GetVagrantBoxAvailVersionDetails() for more
 	// In seconds (5 minutes)
 	VagrantBoxAvailVersionDetailsCacheTimeout int64 = 5 * 60
+
+	// VBoxManageCacheTimeout is a timeout for executing VBoxManage showvminfo
+	// See naksu/box getVMInfoRegexp()
+	VBoxManageCacheTimeout int64 = 15
 )
 
 // AvailableSelection is a struct for a UI/configuration option

--- a/src/naksu/mebroutines/mebroutines.go
+++ b/src/naksu/mebroutines/mebroutines.go
@@ -31,10 +31,6 @@ func Close(c io.Closer) {
 	}
 }
 
-func getErrorStr (err error) string {
-	return fmt.Sprintf("%v", err)
-}
-
 // getRunEnvironment returns array of strings containing environment strings
 func getRunEnvironment() []string {
 	runEnv := os.Environ()
@@ -61,7 +57,7 @@ func Run(commandArgs []string) error {
 
 	err := cmd.Run()
 	if err != nil {
-		ShowWarningMessage(fmt.Sprintf(xlate.Get("command failed: %s (%s)"), strings.Join(commandArgs, " "), getErrorStr(err)))
+		ShowWarningMessage(fmt.Sprintf(xlate.Get("command failed: %s (%v)"), strings.Join(commandArgs, " "), err))
 	}
 
 	return err
@@ -78,9 +74,9 @@ func RunAndGetOutput(commandArgs []string, showWarningOnError bool) (string, err
 	if err != nil {
 		// Executing failed, return error condition
 		if showWarningOnError {
-			ShowWarningMessage(fmt.Sprintf(xlate.Get("command failed: %s (%s)"), strings.Join(commandArgs, " "), getErrorStr(err)))
+			ShowWarningMessage(fmt.Sprintf(xlate.Get("command failed: %s (%v)"), strings.Join(commandArgs, " "), err))
 		} else {
-			log.Debug(fmt.Sprintf(xlate.Get("command failed: %s (%s)"), strings.Join(commandArgs, " "), getErrorStr(err)))
+			log.Debug(fmt.Sprintf(xlate.Get("command failed: %s (%v)"), strings.Join(commandArgs, " "), err))
 		}
 		return string(out), err
 	}
@@ -146,9 +142,9 @@ func RunVagrant(args []string) {
 			log.Debug("Vagrant entered invalid state while booting. We expect this to occur because user has closed the VM window. User was not notified. Complete output:")
 			log.Debug(vagrantOutput)
 		} else {
-			log.Debug(fmt.Sprintf("Failed to execute %s (%s), complete output:", strings.Join(runArgs, " "), getErrorStr(err)))
+			log.Debug(fmt.Sprintf("Failed to execute %s (%v), complete output:", strings.Join(runArgs, " "), err))
 			log.Debug(vagrantOutput)
-			ShowWarningMessage(fmt.Sprintf(xlate.Get("Failed to execute %s (%s)"), strings.Join(runArgs, " "), getErrorStr(err)))
+			ShowWarningMessage(fmt.Sprintf(xlate.Get("Failed to execute %s (%v)"), strings.Join(runArgs, " "), err))
 		}
 	}
 }
@@ -159,9 +155,9 @@ func RunVBoxManage(args []string) string {
 	runArgs := append(vboxmanagepathArr, args...)
 	vBoxManageOutput, err := RunAndGetOutput(runArgs, false)
 	if err != nil {
-		log.Debug(fmt.Sprintf("Failed to execute %s (%s), complete output:", strings.Join(runArgs, " "), getErrorStr(err)))
+		log.Debug(fmt.Sprintf("Failed to execute %s (%v), complete output:", strings.Join(runArgs, " "), err))
 		log.Debug(vBoxManageOutput)
-		ShowErrorMessage(fmt.Sprintf(xlate.Get("Failed to execute %s (%s)"), strings.Join(runArgs, " "), getErrorStr(err)))
+		ShowErrorMessage(fmt.Sprintf(xlate.Get("Failed to execute %s (%v)"), strings.Join(runArgs, " "), err))
 	}
 
 	return vBoxManageOutput

--- a/src/naksu/mebroutines/mebroutines.go
+++ b/src/naksu/mebroutines/mebroutines.go
@@ -31,6 +31,10 @@ func Close(c io.Closer) {
 	}
 }
 
+func getErrorStr (err error) string {
+	return fmt.Sprintf("%v", err)
+}
+
 // getRunEnvironment returns array of strings containing environment strings
 func getRunEnvironment() []string {
 	runEnv := os.Environ()
@@ -57,7 +61,7 @@ func Run(commandArgs []string) error {
 
 	err := cmd.Run()
 	if err != nil {
-		ShowWarningMessage(fmt.Sprintf(xlate.Get("command failed: %s"), strings.Join(commandArgs, " ")))
+		ShowWarningMessage(fmt.Sprintf(xlate.Get("command failed: %s (%s)"), strings.Join(commandArgs, " "), getErrorStr(err)))
 	}
 
 	return err
@@ -74,9 +78,9 @@ func RunAndGetOutput(commandArgs []string, showWarningOnError bool) (string, err
 	if err != nil {
 		// Executing failed, return error condition
 		if showWarningOnError {
-			ShowWarningMessage(fmt.Sprintf(xlate.Get("command failed: %s"), strings.Join(commandArgs, " ")))
+			ShowWarningMessage(fmt.Sprintf(xlate.Get("command failed: %s (%s)"), strings.Join(commandArgs, " "), getErrorStr(err)))
 		} else {
-			log.Debug(fmt.Sprintf(xlate.Get("command failed: %s"), strings.Join(commandArgs, " ")))
+			log.Debug(fmt.Sprintf(xlate.Get("command failed: %s (%s)"), strings.Join(commandArgs, " "), getErrorStr(err)))
 		}
 		return string(out), err
 	}
@@ -142,9 +146,9 @@ func RunVagrant(args []string) {
 			log.Debug("Vagrant entered invalid state while booting. We expect this to occur because user has closed the VM window. User was not notified. Complete output:")
 			log.Debug(vagrantOutput)
 		} else {
-			log.Debug(fmt.Sprintf("Failed to execute %s, complete output:", strings.Join(runArgs, " ")))
+			log.Debug(fmt.Sprintf("Failed to execute %s (%s), complete output:", strings.Join(runArgs, " "), getErrorStr(err)))
 			log.Debug(vagrantOutput)
-			ShowWarningMessage(fmt.Sprintf(xlate.Get("Failed to execute %s"), strings.Join(runArgs, " ")))
+			ShowWarningMessage(fmt.Sprintf(xlate.Get("Failed to execute %s (%s)"), strings.Join(runArgs, " "), getErrorStr(err)))
 		}
 	}
 }
@@ -155,9 +159,9 @@ func RunVBoxManage(args []string) string {
 	runArgs := append(vboxmanagepathArr, args...)
 	vBoxManageOutput, err := RunAndGetOutput(runArgs, false)
 	if err != nil {
-		log.Debug(fmt.Sprintf("Failed to execute %s, complete output:", strings.Join(runArgs, " ")))
+		log.Debug(fmt.Sprintf("Failed to execute %s (%s), complete output:", strings.Join(runArgs, " "), getErrorStr(err)))
 		log.Debug(vBoxManageOutput)
-		ShowErrorMessage(fmt.Sprintf(xlate.Get("Failed to execute %s"), strings.Join(runArgs, " ")))
+		ShowErrorMessage(fmt.Sprintf(xlate.Get("Failed to execute %s (%s)"), strings.Join(runArgs, " "), getErrorStr(err)))
 	}
 
 	return vBoxManageOutput

--- a/src/naksu/naksu.go
+++ b/src/naksu/naksu.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	"naksu/boxversion"
+	"os"
+	"strings"
+
+	"naksu/box"
 	"naksu/config"
 	"naksu/log"
 	"naksu/mebroutines"
 	"naksu/xlate"
-	"os"
-	"strings"
 
 	flags "github.com/jessevdk/go-flags"
 	"github.com/kardianos/osext"
@@ -101,7 +102,7 @@ func main() {
 
 	logDirectoryPaths()
 
-	log.Debug(fmt.Sprintf("Currently installed box: %s", boxversion.GetVagrantFileVersion("")))
+	log.Debug(fmt.Sprintf("Currently installed box: %s %s", box.GetVersion(), box.GetType()))
 
 	// Check whether we have a terminal (restart with x-terminal-emulator, if missing)
 	if !mebroutines.ExistsStdin() {

--- a/src/naksu/ui.go
+++ b/src/naksu/ui.go
@@ -304,6 +304,7 @@ func setupMainLoop(mainUIStatus chan string, mainUINetupdate *time.Ticker) {
 						if box.GetVersion() == "" {
 							buttonStartServer.Disable()
 						} else {
+							updateStartButtonLabel()
 							buttonStartServer.Enable()
 						}
 
@@ -369,6 +370,21 @@ func checkAbittiUpdate() (bool, string) {
 	return abittiUpdate, availAbittiVersion
 }
 
+// updateStartButtonLabel updates label for start button depending on the
+// installed VM style. If there is no box installed the default label is set.
+func updateStartButtonLabel() {
+	go func() {
+		boxTypeString := boxversion.GetVagrantBoxType(box.GetType())
+		ui.QueueMain(func () {
+			if boxTypeString == "-" {
+				buttonStartServer.SetText(xlate.Get("Start Exam Server"))
+			} else {
+				buttonStartServer.SetText(fmt.Sprintf(xlate.Get("Start %s"), boxTypeString))
+			}
+		})
+	}()
+}
+
 // updateVagrantBoxAvailLabel updates UI "update available" label if the currently
 // installed box is Abitti and there is new version available
 func updateVagrantBoxAvailLabel() {
@@ -415,7 +431,7 @@ func updateGetServerButtonLabel() {
 
 func translateUILabels() {
 	ui.QueueMain(func() {
-		buttonStartServer.SetText(xlate.Get("Start Exam Server"))
+		updateStartButtonLabel()
 		updateGetServerButtonLabel()
 		buttonSwitchServer.SetText(xlate.Get("Matriculation Exam"))
 		buttonDestroyServer.SetText(xlate.Get("Remove Exams"))

--- a/src/naksu/ui.go
+++ b/src/naksu/ui.go
@@ -350,14 +350,12 @@ func setupMainLoop(mainUIStatus chan string, mainUINetupdate *time.Ticker) {
 // checkAbittiUpdate checks
 // 1) if currently installed box is Abitti
 // 2) and there is a new version available
-func checkAbittiUpdate() (bool, string, string) {
+func checkAbittiUpdate() (bool, string) {
 	abittiUpdate := false
-	currentAbittiVersion := ""
 	availAbittiVersion := ""
 
 	currentBoxType, currentBoxVersion, errCurrent := boxversion.GetVagrantFileVersionDetails(filepath.Join(mebroutines.GetVagrantDirectory(), "Vagrantfile"))
 	if errCurrent == nil && boxversion.GetVagrantBoxTypeIsAbitti(currentBoxType) {
-		currentAbittiVersion = currentBoxVersion
 		_, availBoxVersion, errAvail := boxversion.GetVagrantBoxAvailVersionDetails()
 		if errAvail == nil && currentBoxVersion != availBoxVersion {
 			abittiUpdate = true
@@ -365,14 +363,14 @@ func checkAbittiUpdate() (bool, string, string) {
 		}
 	}
 
-	return abittiUpdate, currentAbittiVersion, availAbittiVersion
+	return abittiUpdate, availAbittiVersion
 }
 
 // updateVagrantBoxAvailLabel updates UI "update available" label if the currently
 // installed box is Abitti and there is new version available
 func updateVagrantBoxAvailLabel() {
 	go func() {
-		abittiUpdate, _, _ := checkAbittiUpdate()
+		abittiUpdate, _ := checkAbittiUpdate()
 		if abittiUpdate {
 			vagrantBoxAvailVersion := boxversion.GetVagrantBoxAvailVersion()
 			ui.QueueMain(func() {
@@ -399,10 +397,10 @@ func updateGetServerButtonLabel() {
 	}
 
 	go func() {
-		abittiUpdate, currentAbittiVersion, availAbittiVersion := checkAbittiUpdate()
+		abittiUpdate, availAbittiVersion := checkAbittiUpdate()
 		if abittiUpdate {
 			ui.QueueMain(func() {
-				buttonGetServer.SetText(fmt.Sprintf(xlate.Get("Abitti Exam (v%s > v%s)"), currentAbittiVersion, availAbittiVersion))
+				buttonGetServer.SetText(fmt.Sprintf(xlate.Get("Abitti Exam (%s)"), availAbittiVersion))
 			})
 		} else {
 			ui.QueueMain(func() {

--- a/src/naksu/xlate/xlate.go
+++ b/src/naksu/xlate/xlate.go
@@ -12,7 +12,7 @@ func SetLanguage(newLanguage string) {
 			// Main window, buttons
 			"Start Exam Server":                 "Käynnistä koetilan palvelin",
 			"Abitti Exam":                       "Abitti-koe",
-			"Abitti Exam (v%s > v%s)":           "Abitti-koe (v%s > v%s)",
+			"Abitti Exam (%s)":                  "Abitti-koe (%s)",
 			"Matriculation Exam":                "Yo-koe",
 			"Remove Exams":                      "Poista kokeet",
 			"Remove Server":                     "Poista palvelin",
@@ -122,7 +122,7 @@ func SetLanguage(newLanguage string) {
 			// Main window, buttons
 			"Start Exam Server":                 "Starta provlokalsserver",
 			"Abitti Exam":                       "Abitti-prov",
-			"Abitti Exam (v%s > v%s)":           "Abitti-prov (v%s > v%s)",
+			"Abitti Exam (%s)":                  "Abitti-prov (%s)",
 			"Matriculation Exam":                "Studentprovet",
 			"Remove Exams":                      "Avlägsna proven",
 			"Remove Server":                     "Avlägsna servern",

--- a/src/naksu/xlate/xlate.go
+++ b/src/naksu/xlate/xlate.go
@@ -11,6 +11,7 @@ func SetLanguage(newLanguage string) {
 		xlateStrings = map[string]string{
 			// Main window, buttons
 			"Start Exam Server":                 "Käynnistä koetilan palvelin",
+			"Start %s":                          "Käynnistä %s",
 			"Abitti Exam":                       "Abitti-koe",
 			"Abitti Exam (%s)":                  "Abitti-koe (%s)",
 			"Matriculation Exam":                "Yo-koe",
@@ -69,8 +70,6 @@ func SetLanguage(newLanguage string) {
 			"Server was removed succesfully.": "Palvelimen poistaminen onnistui.",
 
 			// mebroutines
-			"Abitti server":         "Abitti-palvelin",
-			"Matric Exam server":    "Yo-palvelin",
 			"command failed: %s":    "komento epäonnistui: %s",
 			"Failed to execute %s":  "Komennon suorittaminen epäonnistui: %s",
 			"Could not chdir to %s": "Hakemistoon %s siirtyminen epäonnistui",
@@ -116,11 +115,16 @@ func SetLanguage(newLanguage string) {
 
 			// start
 			// Already defined: "Could not change to vagrant directory ~/ktp"
+
+			// boxversion
+			"Abitti server":      "Abitti-palvelin",
+			"Matric Exam server": "Yo-palvelin",
 		}
 	} else if currentLanguage == "sv" {
 		xlateStrings = map[string]string{
 			// Main window, buttons
 			"Start Exam Server":                 "Starta provlokalsserver",
+			"Start %s":                          "Starta %s",
 			"Abitti Exam":                       "Abitti-prov",
 			"Abitti Exam (%s)":                  "Abitti-prov (%s)",
 			"Matriculation Exam":                "Studentprovet",
@@ -179,8 +183,6 @@ func SetLanguage(newLanguage string) {
 			"Server was removed succesfully.": "Avlägsning av servern lyckades.",
 
 			// mebroutines
-			"Abitti server":         "Abitti-server",
-			"Matric Exam server":    "Examensserver",
 			"command failed: %s":    "Komandot misslyckades: %s",
 			"Failed to execute %s":  "Utförning av komandot misslyckades: %s",
 			"Could not chdir to %s": "Förflyttning till katalogen %s misslyckades",
@@ -226,6 +228,10 @@ func SetLanguage(newLanguage string) {
 
 			// start
 			// Already defined: "Could not change to vagrant directory ~/ktp"
+
+			// boxversion
+			"Abitti server":      "Abitti-server",
+			"Matric Exam server": "Examensserver",
 		}
 	} else {
 		xlateStrings = nil


### PR DESCRIPTION
This feature gets VM box version string and type directly from VirtualBox using "VBoxManage showvminfo". The values are set by the version-specific `Vagrantfile`.

Originally the version string and type were read from `~/ktp/Vagrantfile`. The feature was needed as after an failed image download resulted UI to show an installed version number which was not really installed.