### PR TITLE
Fix: "Remove server" failed to delete ~/ktp on Windows host

### DIFF
--- a/src/naksu/log/log.go
+++ b/src/naksu/log/log.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 var isDebug bool
 var debugFilename string
 var logger *log.Logger
+var loggerWriter io.WriteCloser
 
 func appendLogFile(message string) {
 	if debugFilename != "" {
@@ -37,16 +39,27 @@ func SetDebug(newValue bool) {
 }
 
 // SetDebugFilename sets debug log path
+// Setting filename of "-" prints errors to standard error
 func SetDebugFilename(newFilename string) {
 	debugFilename = newFilename
 
-	lumberLog := lumberjack.Logger{
-		Filename:   debugFilename,
-		MaxSize:    1, // megabytes
-		MaxBackups: 3,
+	if loggerWriter != nil {
+		loggerWriter.Close()
 	}
 
-	logger = log.New(&lumberLog, "", log.Ldate|log.Ltime)
+	if newFilename == "-" {
+		loggerWriter = os.Stderr
+	} else {
+		lumberLog := lumberjack.Logger{
+			Filename:   debugFilename,
+			MaxSize:    1, // megabytes
+			MaxBackups: 3,
+		}
+
+		loggerWriter = &lumberLog
+	}
+
+	logger = log.New(loggerWriter, "", log.Ldate|log.Ltime)
 }
 
 // GetNewDebugFilename suggests a new debug log filename

--- a/src/naksu/log/log.go
+++ b/src/naksu/log/log.go
@@ -44,7 +44,11 @@ func SetDebugFilename(newFilename string) {
 	debugFilename = newFilename
 
 	if loggerWriter != nil {
-		loggerWriter.Close()
+		err := loggerWriter.Close()
+		if err != nil {
+			// nolint: gosec, errcheck
+			os.Stderr.WriteString(fmt.Sprintf("Could not close log file: %v", err))
+		}
 	}
 
 	if newFilename == "-" {

--- a/src/naksu/mebroutines/remove/remove.go
+++ b/src/naksu/mebroutines/remove/remove.go
@@ -34,6 +34,9 @@ func Server() error {
 		return err
 	}
 
+	// Close current debug file in case it is located in ~/ktp
+	log.SetDebugFilename("-")
+
 	progress.TranslateAndSetMessage("Deleting ~/ktp")
 	err = mebroutines.RemoveDir(mebroutines.GetVagrantDirectory())
 	if err != nil {


### PR DESCRIPTION
Lokien rotatoinnin toteutus piti lokitiedoston auki, ja Windowsissa tämä lukko esti Poista palvelin -toiminnon käytön, koska ~/ktp/naksu_lastlog.txt oli lukittu naksu.exe:lle.

Nyt lokitulostus ohjataan STDERRiin ennen ko. hakemiston poistoa.
