### PR TITLE
Feature/show NIC on Linux

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 FROM ubuntu:bionic
-RUN apt-get update && apt-get -y install zip wget curl golang-1.10 libgtk-3-dev gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64 git
+RUN apt-get update && apt-get -y install zip wget curl golang-1.10 libgtk-3-dev gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64 git libusb-1.0-0-dev
 ENV PATH="/usr/lib/go-1.10/bin/:/root/go/bin:${PATH}"
 RUN mkdir -p /root/go/bin && curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 COPY Makefile /app/

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ bin/go2xunit:
 	GOPATH=$(current_dir)/ go get github.com/tebeka/go2xunit
 
 checkstyle: bin/gometalinter
-	-GOOS=linux GOARCH=amd64 CGO_ENABLED=1 ./bin/gometalinter --deadline=240s --vendor --checkstyle ./src/naksu/... > checkstyle-linux.xml
+	-GOOS=linux GOARCH=amd64 CGO_ENABLED=1 ./bin/gometalinter --deadline=240s --vendor \
+		--exclude ./src/naksu/vendor/github.com/google/gousb --checkstyle ./src/naksu/... > checkstyle-linux.xml
 	-GOOS=windows GOARCH=amd64 CGO_ENABLED=1 ./bin/gometalinter --deadline=240s --vendor --checkstyle ./src/naksu/... > checkstyle-windows.xml
 
 lint: bin/gometalinter

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ and build a Mac OS X binary with
 
 `make darwin-docker`
 
-Mac OS X test version can be started with command `./bin/naksu-darwin
+Mac OS X test version can be started with command `./bin/naksu-darwin`
+
 ## Compilation details
 
 Preferred way to compile `naksu` is using Docker.
@@ -105,6 +106,7 @@ Make sure `go` points to your compiler or set `GO` to point your go binary (in `
 ### Building Linux version
 
 - Install `libgtk-3-dev` which is required by `libui`.
+- Install `libusb-1.0-0-dev` which is required by `github.com/google/gousb/usbid`.
 - Run `make update_libs` to get all required golang dependencies.
 - `make linux`
 

--- a/src/naksu/Gopkg.lock
+++ b/src/naksu/Gopkg.lock
@@ -161,6 +161,14 @@
   revision = "1a4a6f06a1c643c8fbd339bd61d980960627d09e"
 
 [[projects]]
+  digest = "1:d541be58c42bf6025cb539e7f36df691d4b476359bf97d9296a521a63e688f3f"
+  name = "github.com/jaypipes/pcidb"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "98ef3ee36c69f20650fe7855047ad042338c6983"
+  version = "v0.5.0"
+
+[[projects]]
   branch = "master"
   digest = "1:4bb169ce06341a7c5e6c9a6734b25c606f59e2f765703301f92d159cf999672e"
   name = "github.com/jessevdk/go-flags"
@@ -289,6 +297,7 @@
     "github.com/dustin/go-humanize",
     "github.com/go-ini/ini",
     "github.com/intel-go/cpuid",
+    "github.com/jaypipes/pcidb",
     "github.com/jessevdk/go-flags",
     "github.com/kardianos/osext",
     "github.com/mitchellh/go-homedir",

--- a/src/naksu/Gopkg.lock
+++ b/src/naksu/Gopkg.lock
@@ -141,6 +141,17 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:7784cd19b0c20bd9ddc181889e1a86baac8c1d735752f2cb3fb61ef2bf9fbe8f"
+  name = "github.com/google/gousb"
+  packages = [
+    ".",
+    "usbid",
+  ]
+  pruneopts = "UT"
+  revision = "e4c3f66a1571a02d7cae859fa0be08edcb940541"
+  version = "v1.1.0"
+
+[[projects]]
   branch = "master"
   digest = "1:f3b0cfd42716269884bf06df5d5be9e54161d5af0a2f0ccca08717928dd45fc5"
   name = "github.com/inconshreveable/go-update"
@@ -296,6 +307,8 @@
     "github.com/blang/semver",
     "github.com/dustin/go-humanize",
     "github.com/go-ini/ini",
+    "github.com/google/gousb",
+    "github.com/google/gousb/usbid",
     "github.com/intel-go/cpuid",
     "github.com/jaypipes/pcidb",
     "github.com/jessevdk/go-flags",

--- a/src/naksu/network/network_linux.go
+++ b/src/naksu/network/network_linux.go
@@ -97,7 +97,7 @@ func getPCIDeviceLegend(vendor string, device string) (string, error) {
 	}
 
 	log.Debug(fmt.Sprintf("Did not find any matches from PCI database for key %s", searchKey))
-	return "", errors.New("No matching legend found")
+	return "", errors.New("no matching legend found")
 }
 
 func getExtInterfaceDefaultLegend(extInterface string) string {


### PR DESCRIPTION
Shows NIC product name for PCI and USB network devices (even vendor on USB devices) on Linux hosts. The device ID databases must be installed (Debian packages `usbutils`, `pciutils`).
