### PR TITLE
Fix error message shown to user

### DIFF
--- a/src/naksu/mebroutines/mebroutines.go
+++ b/src/naksu/mebroutines/mebroutines.go
@@ -153,8 +153,9 @@ func RunVBoxManage(args []string) (string, error) {
 	runArgs := append(vboxmanagepathArr, args...)
 	vBoxManageOutput, err := RunAndGetOutput(runArgs)
 	if err != nil {
+		command := strings.Join(runArgs, " ")
 		logError := func(output string, err error) {
-			log.Debug(fmt.Sprintf("Failed to execute %s (%v), complete output:", strings.Join(runArgs, " "), err))
+			log.Debug(fmt.Sprintf("Failed to execute %s (%v), complete output:", command, err))
 			log.Debug(output)
 		}
 
@@ -162,11 +163,11 @@ func RunVBoxManage(args []string) (string, error) {
 
 		fixed, fixErr := detectAndFixDuplicateHardDiskProblem(vBoxManageOutput)
 		if !fixed || fixErr != nil {
-			log.Debug(fmt.Sprintf("Failed to detect & fix duplicate hard disk problem: %v", fixErr))
-			return "", errors.New("failed to fix duplicate hard disk problem")
+			log.Debug(fmt.Sprintf("Failed to fix problem with command %s (%v)", command, fixErr))
+			return "", fmt.Errorf(xlate.Get("Failed to execute %s: %v"), command, err)
 		}
 
-		log.Debug(fmt.Sprintf("Retrying '%s' after fixing problem", strings.Join(runArgs, " ")))
+		log.Debug(fmt.Sprintf("Retrying '%s' after fixing problem", command))
 		vBoxManageOutput, err = RunAndGetOutput(runArgs)
 		if err != nil {
 			logError(vBoxManageOutput, err)


### PR DESCRIPTION
This issue was introduced by the "don't croak" commit
(234d0425d6e3a5f3675527ca27b41c5b0dea9f8a). The problem is as follows:
1. Executing VBoxManage fails for some unknown reason.
2. Naksu checks if the cause is the known duplicate hard disk issue.
   That's not the case, so fixed = false.
3. Naksu logs "Failed to detect & fix duplicate hard disk problem" (which
   is inaccurate: there was no duplicate hard disk problem and naksu did
   not "fail" to detect it --- it simply wasn't present).
4. The user sees an error message saying "failed to fix duplicate hard
   disk problem", which leads support personnel astray when debugging
   the problem.

After this change, the logging and the error message are more or less
the same as they were before: the user sees the original VBoxManage
error which is useful for support personnel, and the logs describe the
issue more accurately.