### PR TITLE
Getting ready to 2021 Spring Exams

### DIFF
--- a/res/gettext/fi.po
+++ b/res/gettext/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-11-28 17:22+0200\n"
-"PO-Revision-Date: 2021-01-17 16:36+0200\n"
+"PO-Revision-Date: 2021-02-05 21:05+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: fi\n"
@@ -52,6 +52,9 @@ msgstr "Virtuaalikone on käynnistetty"
 
 msgid "Could not get version string for a new server: %v"
 msgstr "Uuden palvelin versiotiedon haku epäonnistui: %v"
+
+msgid "Please check the install passphrase"
+msgstr "Tarkista palvelimen asennuskoodi"
 
 msgid "Could not create directory: %v"
 msgstr "Hakemiston luominen epäonnistui: %v"

--- a/res/gettext/naksu.pot
+++ b/res/gettext/naksu.pot
@@ -48,6 +48,9 @@ msgstr ""
 msgid "Could not get version string for a new server: %v"
 msgstr ""
 
+msgid "Please check the install passphrase"
+msgstr ""
+
 msgid "Could not create directory: %v"
 msgstr ""
 

--- a/res/gettext/sv.po
+++ b/res/gettext/sv.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-11-28 17:22+0200\n"
-"PO-Revision-Date: 2021-01-17 16:39+0200\n"
+"PO-Revision-Date: 2021-02-05 21:06+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: sv\n"
@@ -52,6 +52,9 @@ msgstr "Den virtuella maskinen har startats"
 
 msgid "Could not get version string for a new server: %v"
 msgstr "Kunde inte erhålla versionsuppgifterna för ny server: %v"
+
+msgid "Please check the install passphrase"
+msgstr "Kontrollera installationskoden för examensservern"
 
 msgid "Could not create directory: %v"
 msgstr "Det gick inte att skapa katalogen: %v"

--- a/src/naksu/box/box.go
+++ b/src/naksu/box/box.go
@@ -118,6 +118,11 @@ func CreateNewBox(boxType string, boxVersion string) error {
 			"--type", "hdd",
 			"--medium", mebroutines.GetVDIImagePath(),
 		},
+		{
+			"setextradata", boxName,
+			"GUI/RestrictedCloseActions",
+			"SaveState,PowerOffRestoringSnapshot",
+		},
 	}
 
 	v6_1String := "6.1.0"

--- a/src/naksu/log/log.go
+++ b/src/naksu/log/log.go
@@ -90,12 +90,22 @@ func IsDebug() bool {
 	return isDebug
 }
 
-// Debug logs debug information to log file
-func Debug(message string, vars ...interface{}) {
+// writeLogMessage writes log entries with the specified prefix
+func writeLogMessage(prefix string, message string, vars ...interface{}) {
 	formattedMessage := fmt.Sprintf(message, vars...)
 	if IsDebug() {
-		fmt.Printf("DEBUG: %s\n", formattedMessage)
+		fmt.Printf("%s: %s\n", prefix, formattedMessage)
 	}
 
-	appendLogFile(fmt.Sprintf("DEBUG: %s", formattedMessage))
+	appendLogFile(fmt.Sprintf("%s: %s", prefix, formattedMessage))
+}
+
+// Debug logs debug information to log file
+func Debug(message string, vars ...interface{}) {
+	writeLogMessage("DEBUG", message, vars...)
+}
+
+// Action logs action information (i.e. user action) to log file
+func Action(message string, vars ...interface{}) {
+	writeLogMessage("ACTION", message, vars...)
 }

--- a/src/naksu/log/log.go
+++ b/src/naksu/log/log.go
@@ -93,7 +93,7 @@ func IsDebug() bool {
 // writeLogMessage writes log entries with the specified prefix
 func writeLogMessage(prefix string, message string, vars ...interface{}) {
 	formattedMessage := fmt.Sprintf(message, vars...)
-	if IsDebug() {
+	if (prefix == "DEBUG" && IsDebug()) || prefix != "DEBUG" {
 		fmt.Printf("%s: %s\n", prefix, formattedMessage)
 	}
 
@@ -103,6 +103,21 @@ func writeLogMessage(prefix string, message string, vars ...interface{}) {
 // Debug logs debug information to log file
 func Debug(message string, vars ...interface{}) {
 	writeLogMessage("DEBUG", message, vars...)
+}
+
+// Error logs error message to log file
+func Error(message string, vars ...interface{}) {
+	writeLogMessage("ERROR", message, vars...)
+}
+
+// Warning logs warning information to log file
+func Warning(message string, vars ...interface{}) {
+	writeLogMessage("WARNING", message, vars...)
+}
+
+// Warning logs info message to log file
+func Info(message string, vars ...interface{}) {
+	writeLogMessage("INFO", message, vars...)
 }
 
 // Action logs action information (i.e. user action) to log file

--- a/src/naksu/mebroutines/install/install.go
+++ b/src/naksu/mebroutines/install/install.go
@@ -21,6 +21,11 @@ import (
 
 // newServer downloads and creates new Abitti or Exam server using the given image URL
 func newServer(boxType string, imageURL string, versionURL string) {
+	// Check prerequisites
+	if ensureServerIsNotRunningAndDoesNotExist() != nil || ensureDiskIsReady() != nil {
+		return
+	}
+
 	version, err := download.GetAvailableVersion(versionURL)
 	switch fmt.Sprintf("%v", err) {
 	case "<nil>":
@@ -29,25 +34,6 @@ func newServer(boxType string, imageURL string, versionURL string) {
 		return
 	default:
 		mebroutines.ShowTranslatedErrorMessage("Could not get version string for a new server: %v", err)
-		return
-	}
-
-	err = ensureServerIsNotRunningAndDoesNotExist()
-	if err != nil {
-		return
-	}
-
-	err = ensureNaksuDirectoriesExist()
-	if err != nil {
-		log.Debug(fmt.Sprintf("Failed to ensure Naksu directories exist: %v", err))
-		mebroutines.ShowTranslatedErrorMessage("Could not create directory: %v", err)
-		return
-	}
-
-	err = ensureFreeDisk()
-	if err != nil {
-		log.Debug(fmt.Sprintf("Failed to ensure we have enough free disk: %v", err))
-		mebroutines.ShowTranslatedErrorMessage("Could not calculate free disk size: %v", err)
 		return
 	}
 
@@ -118,6 +104,24 @@ func ensureServerIsNotRunningAndDoesNotExist() error {
 		if errRemove != nil {
 			mebroutines.ShowTranslatedWarningMessage("Could not remove current VM before installing new one: %v", errRemove)
 		}
+	}
+
+	return nil
+}
+
+func ensureDiskIsReady() error {
+	err := ensureNaksuDirectoriesExist()
+	if err != nil {
+		log.Debug(fmt.Sprintf("Failed to ensure Naksu directories exist: %v", err))
+		mebroutines.ShowTranslatedErrorMessage("Could not create directory: %v", err)
+		return err
+	}
+
+	err = ensureFreeDisk()
+	if err != nil {
+		log.Debug(fmt.Sprintf("Failed to ensure we have enough free disk: %v", err))
+		mebroutines.ShowTranslatedErrorMessage("Could not calculate free disk size: %v", err)
+		return err
 	}
 
 	return nil

--- a/src/naksu/mebroutines/install/install.go
+++ b/src/naksu/mebroutines/install/install.go
@@ -22,7 +22,12 @@ import (
 // newServer downloads and creates new Abitti or Exam server using the given image URL
 func newServer(boxType string, imageURL string, versionURL string) {
 	version, err := download.GetAvailableVersion(versionURL)
-	if err != nil {
+	switch fmt.Sprintf("%v", err) {
+	case "<nil>":
+	case "404":
+		mebroutines.ShowTranslatedErrorMessage("Please check the install passphrase")
+		return
+	default:
 		mebroutines.ShowTranslatedErrorMessage("Could not get version string for a new server: %v", err)
 		return
 	}

--- a/src/naksu/mebroutines/mebroutines.go
+++ b/src/naksu/mebroutines/mebroutines.go
@@ -267,8 +267,7 @@ func SetMainWindow(win *ui.Window) {
 
 // ShowErrorMessage shows error message popup to user
 func ShowErrorMessage(message string) {
-	fmt.Printf("ERROR: %s\n\n", message)
-	log.Debug(fmt.Sprintf("ERROR: %s", message))
+	log.Error(message)
 
 	// Show libui box if main window has been set with Set_main_window
 	if mainWindow != nil {
@@ -284,9 +283,8 @@ func ShowTranslatedErrorMessage(str string, vars ...interface{}) {
 }
 
 // ShowWarningMessage shows warning message popup to user
-func ShowWarningMessage(message string, vars ...interface{}) {
-	fmt.Printf("WARNING: %s\n", message)
-	log.Debug(fmt.Sprintf("WARNING: %s", message))
+func ShowWarningMessage(message string) {
+	log.Warning(message)
 
 	// Show libui box if main window has been set with Set_main_window
 	if mainWindow != nil {
@@ -302,16 +300,13 @@ func ShowTranslatedWarningMessage(str string, vars ...interface{}) {
 }
 
 // ShowInfoMessage shows warning message popup to user
-func ShowInfoMessage(str string, vars ...interface{}) {
-	translated := xlate.Get(str, vars...)
-
-	fmt.Printf("INFO: %s\n", translated)
-	log.Debug(fmt.Sprintf("INFO: %s", translated))
+func ShowInfoMessage(message string) {
+	log.Info(message)
 
 	// Show libui box if main window has been set with Set_main_window
 	if mainWindow != nil {
 		ui.QueueMain(func() {
-			ui.MsgBox(mainWindow, xlate.Get("Info"), translated)
+			ui.MsgBox(mainWindow, xlate.Get("Info"), message)
 		})
 	}
 }

--- a/src/naksu/mebroutines/mebroutines.go
+++ b/src/naksu/mebroutines/mebroutines.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"naksu/log"
@@ -206,8 +207,20 @@ func GetMebshareDirectory() string {
 	return filepath.Join(GetHomeDirectory(), "ktp-jako")
 }
 
-// GetVirtualBoxHiddenDirectory returns ".VirtualBox" path from under home directory
+// GetVirtualBoxHiddenDirectory returns path to global VirtualBox settings
+// https://docs.oracle.com/en/virtualization/virtualbox/6.0/admin/vboxconfigdata.html
 func GetVirtualBoxHiddenDirectory() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(GetHomeDirectory(), "Library", "VirtualBox")
+	case "linux":
+		return filepath.Join(GetHomeDirectory(), ".config", "VirtualBox")
+	case "windows":
+		return filepath.Join(GetHomeDirectory(), ".VirtualBox")
+	default:
+		log.Debug("GetVirtualBoxHiddenDirectory() could not detect execution environment")
+	}
+
 	return filepath.Join(GetHomeDirectory(), ".VirtualBox")
 }
 

--- a/src/naksu/mebroutines/remove/remove.go
+++ b/src/naksu/mebroutines/remove/remove.go
@@ -20,8 +20,6 @@ func Server() error {
 		mebroutines.ShowWarningMessage("There is a server appears to be running but we remove it as you requested.")
 	}
 
-	var err error
-
 	// Chdir to home directory to avoid problems with Windows where deleting
 	// a directory where the process is running
 	progress.TranslateAndSetMessage("Chdir ~")
@@ -30,23 +28,14 @@ func Server() error {
 	}
 
 	progress.TranslateAndSetMessage("Deleting ~/.VirtualBox")
-	err = mebroutines.RemoveDir(mebroutines.GetVirtualBoxHiddenDirectory())
-	if err != nil {
-		deleteFailed(mebroutines.GetVirtualBoxHiddenDirectory(), err)
-		return err
-	}
+	mebroutines.RemoveDirAndLogErrors(mebroutines.GetVirtualBoxHiddenDirectory())
 
 	progress.TranslateAndSetMessage("Deleting ~/VirtualBox VMs")
-	err = mebroutines.RemoveDir(mebroutines.GetVirtualBoxVMsDirectory())
+	err := mebroutines.RemoveDir(mebroutines.GetVirtualBoxVMsDirectory())
 	if err != nil {
-		deleteFailed(mebroutines.GetVirtualBoxVMsDirectory(), err)
+		mebroutines.ShowWarningMessage(fmt.Sprintf("Failed to remove directory %s: %v", mebroutines.GetVirtualBoxVMsDirectory(), err))
 		return err
 	}
 
 	return nil
-}
-
-// deleteFailed gives user an error message
-func deleteFailed(failedPath string, err error) {
-	mebroutines.ShowWarningMessage(fmt.Sprintf("Failed to remove directory %s: %v", failedPath, err))
 }

--- a/src/naksu/naksu.go
+++ b/src/naksu/naksu.go
@@ -99,7 +99,7 @@ func main() {
 	// Determine/set path for debug log
 	log.SetDebugFilename(log.GetNewDebugFilename())
 
-	log.Debug("This is Naksu %s. Hello world!", version)
+	log.Action("This is Naksu %s. Hello world!", version)
 
 	logDirectoryPaths()
 
@@ -111,5 +111,5 @@ func main() {
 		panic(err)
 	}
 
-	log.Debug("Exiting GUI loop")
+	log.Action("Exiting GUI loop")
 }

--- a/src/naksu/ui.go
+++ b/src/naksu/ui.go
@@ -614,7 +614,9 @@ func enableUI(mainUIStatus chan string) {
 func bindLanguageSwitching() {
 	// Define language selection action main window
 	comboboxLang.OnSelected(func(*ui.Combobox) {
-		config.SetLanguage(constants.AvailableLangs[comboboxLang.Selected()].ConfigValue)
+		newValue := constants.AvailableLangs[comboboxLang.Selected()].ConfigValue
+		log.Action("Changing language to %s", newValue)
+		config.SetLanguage(newValue)
 
 		xlate.SetLanguage(config.GetLanguage())
 		progress.SetMessage("")
@@ -628,10 +630,12 @@ func bindAdvancedToggle() {
 		switch checkboxAdvanced.Checked() {
 		case true:
 			{
+				log.Action("Opening advanced features")
 				boxAdvanced.Show()
 			}
 		case false:
 			{
+				log.Action("Closing advances features")
 				boxAdvanced.Hide()
 			}
 		}
@@ -641,14 +645,18 @@ func bindAdvancedToggle() {
 func bindAdvancedExtNicSwitching() {
 	// Define EXTNIC selection action main window (advanced view)
 	comboboxExtNic.OnSelected(func(*ui.Combobox) {
-		config.SetExtNic(extInterfaces[comboboxExtNic.Selected()].ConfigValue)
+		newValue := extInterfaces[comboboxExtNic.Selected()].ConfigValue
+		log.Action("Changing external network to %s", newValue)
+		config.SetExtNic(newValue)
 	})
 }
 
 func bindAdvancedNicSwitching() {
 	// Define NIC selection action main window (advanced view)
 	comboboxNic.OnSelected(func(*ui.Combobox) {
-		config.SetNic(constants.AvailableNics[comboboxNic.Selected()].ConfigValue)
+		newValue := constants.AvailableNics[comboboxNic.Selected()].ConfigValue
+		log.Action("Changing server networking hardware to %s", newValue)
+		config.SetNic(newValue)
 	})
 }
 
@@ -662,11 +670,14 @@ func bindUIDisableOnStart(mainUIStatus chan string) {
 	}
 
 	buttonSelfUpdateOn.OnClicked(func(*ui.Button) {
+		log.Action("Enabling self-update")
 		config.SetSelfUpdateDisabled(false)
 	})
 
 	buttonStartServer.OnClicked(func(*ui.Button) {
 		go func() {
+			log.Action("Starting server")
+
 			// Give warnings if there is problems with configured external network device
 			// and there are more than one available
 			if config.GetExtNic() == "" {
@@ -704,7 +715,7 @@ func bindUIDisableOnStart(mainUIStatus chan string) {
 func bindOnInstallAbittiServer(mainUIStatus chan string) {
 	buttonInstallAbittiServer.OnClicked(func(*ui.Button) {
 		go func() {
-			log.Debug("Starting Abitti box update")
+			log.Action("Starting Abitti box update")
 
 			disableUI(mainUIStatus)
 			install.NewAbittiServer()
@@ -719,6 +730,7 @@ func bindOnInstallAbittiServer(mainUIStatus chan string) {
 
 func bindOnInstallExamServer(mainUIStatus chan string) {
 	buttonInstallExamServer.OnClicked(func(*ui.Button) {
+		log.Action("Opening InstallExamServer dialog")
 		disableUI(mainUIStatus)
 		examInstallWindow.Show()
 	})
@@ -729,6 +741,7 @@ func bindOnInstallExamServer(mainUIStatus chan string) {
 			examInstallPassphraseEntry.SetText("")
 			disableUI(mainUIStatus)
 			if passphrase != "" {
+				log.Action("InstallExamServer passhrase entered - Starting Exam box update")
 				examInstallWindow.Hide()
 				install.NewExamServer(passphrase)
 				translateUILabels()
@@ -741,12 +754,14 @@ func bindOnInstallExamServer(mainUIStatus chan string) {
 	})
 
 	examInstallButtonCancel.OnClicked(func(*ui.Button) {
+		log.Action("Cancelling InstallExamServer dialog")
 		examInstallWindow.Hide()
 		examInstallPassphraseEntry.SetText("")
 		enableUI(mainUIStatus)
 	})
 
 	examInstallWindow.OnClosing(func(*ui.Window) bool {
+		log.Action("Closing InstallExamServer dialog")
 		examInstallWindow.Hide()
 		enableUI(mainUIStatus)
 		examInstallPassphraseEntry.SetText("")
@@ -757,6 +772,7 @@ func bindOnInstallExamServer(mainUIStatus chan string) {
 func bindOnDestroyServer(mainUIStatus chan string) {
 	// Define actions for Destroy popup/window
 	buttonDestroyServer.OnClicked(func(*ui.Button) {
+		log.Action("Opening DestroyServer dialog")
 		disableUI(mainUIStatus)
 		destroyWindow.Show()
 	})
@@ -765,6 +781,7 @@ func bindOnDestroyServer(mainUIStatus chan string) {
 func bindOnRemoveServer(mainUIStatus chan string) {
 	// Define actions for Remove popup/window
 	buttonRemoveServer.OnClicked(func(*ui.Button) {
+		log.Action("Opening RemoveServer dialog")
 		disableUI(mainUIStatus)
 		removeWindow.Show()
 	})
@@ -772,6 +789,7 @@ func bindOnRemoveServer(mainUIStatus chan string) {
 
 func bindOnMakeBackup(mainUIStatus chan string) {
 	buttonMakeBackup.OnClicked(func(*ui.Button) {
+		log.Action("Opening Backup dialog")
 		disableUI(mainUIStatus)
 		backupWindow.Show()
 	})
@@ -786,6 +804,7 @@ func setLogDeliveryLabelTextInGoroutine(text string) {
 
 func bindOnDeliverLogs(mainUIStatus chan string) {
 	buttonDeliverLogs.OnClicked(func(*ui.Button) {
+		log.Action("Starting log delivery")
 		disableUI(mainUIStatus)
 		buttonDeliverLogs.Disable()
 
@@ -859,7 +878,7 @@ func followLogDeliveryZippingProgress(zipProgressChannel chan uint8, zipErrorCha
 
 func bindOnMebShare() {
 	buttonMebShare.OnClicked(func(*ui.Button) {
-		log.Debug("Opening MEB share (~/ktp-jako)")
+		log.Action("Opening MEB share (~/ktp-jako)")
 		mebroutines.OpenMebShare()
 	})
 }
@@ -869,7 +888,7 @@ func bindOnBackup(mainUIStatus chan string) {
 	backupButtonSave.OnClicked(func(*ui.Button) {
 		go func() {
 			pathBackup := filepath.Join(backupMediaPath[backupCombobox.Selected()], backup.GetBackupFilename(time.Now()))
-			log.Debug(fmt.Sprintf("Starting backup to: %s", pathBackup))
+			log.Action(fmt.Sprintf("Starting backup to: %s", pathBackup))
 
 			backupWindow.Hide()
 			err := backup.MakeBackup(pathBackup)
@@ -887,11 +906,13 @@ func bindOnBackup(mainUIStatus chan string) {
 	})
 
 	backupButtonCancel.OnClicked(func(*ui.Button) {
+		log.Action("Cancelling Backup dialog")
 		backupWindow.Hide()
 		enableUI(mainUIStatus)
 	})
 
 	backupWindow.OnClosing(func(*ui.Window) bool {
+		log.Action("Closing Backup dialog")
 		backupWindow.Hide()
 		enableUI(mainUIStatus)
 		return false
@@ -900,6 +921,7 @@ func bindOnBackup(mainUIStatus chan string) {
 
 func bindOnLogDelivery(mainUIStatus chan string) {
 	logDeliveryFilenameCopyButton.OnClicked(func(*ui.Button) {
+		log.Action("Copying log filename to clipboard")
 		err := clipboard.WriteAll(logDeliveryFilenameLabel.Text())
 		if err != nil {
 			log.Debug(fmt.Sprintf("Could not write to clipboard: %v", err))
@@ -907,12 +929,14 @@ func bindOnLogDelivery(mainUIStatus chan string) {
 	})
 
 	logDeliveryButtonClose.OnClicked(func(*ui.Button) {
+		log.Action("Closing LogDelivery dialog")
 		logDeliveryWindow.Hide()
 		buttonDeliverLogs.Enable()
 		enableUI(mainUIStatus)
 	})
 
 	logDeliveryWindow.OnClosing(func(*ui.Window) bool {
+		log.Action("Closing LogDelivery dialog")
 		logDeliveryWindow.Hide()
 		buttonDeliverLogs.Enable()
 		enableUI(mainUIStatus)
@@ -927,7 +951,7 @@ func bindOnDestroy(mainUIStatus chan string) {
 
 	destroyButtonDestroy.OnClicked(func(*ui.Button) {
 		go func() {
-			log.Debug("Starting server destroy")
+			log.Action("Starting server destroy")
 
 			destroyWindow.Hide()
 			err := destroy.Server()
@@ -948,11 +972,13 @@ func bindOnDestroy(mainUIStatus chan string) {
 	})
 
 	destroyButtonCancel.OnClicked(func(*ui.Button) {
+		log.Action("Cancelling Destroy dialog")
 		destroyWindow.Hide()
 		enableUI(mainUIStatus)
 	})
 
 	destroyWindow.OnClosing(func(*ui.Window) bool {
+		log.Action("Closing Destroy dialog")
 		destroyWindow.Hide()
 		enableUI(mainUIStatus)
 		return true
@@ -966,7 +992,7 @@ func bindOnRemove(mainUIStatus chan string) {
 
 	removeButtonRemove.OnClicked(func(*ui.Button) {
 		go func() {
-			log.Debug("Starting server remove")
+			log.Action("Starting server remove")
 
 			removeWindow.Hide()
 
@@ -988,11 +1014,13 @@ func bindOnRemove(mainUIStatus chan string) {
 	})
 
 	removeButtonCancel.OnClicked(func(*ui.Button) {
+		log.Action("Cancelling Remove dialog")
 		removeWindow.Hide()
 		enableUI(mainUIStatus)
 	})
 
 	removeWindow.OnClosing(func(*ui.Window) bool {
+		log.Action("Closing Remove dialog")
 		removeWindow.Hide()
 		enableUI(mainUIStatus)
 		return true
@@ -1072,7 +1100,7 @@ func RunUI() error {
 		bindOnRemove(mainUIStatus)
 
 		window.OnClosing(func(*ui.Window) bool {
-			log.Debug("User exits through window exit")
+			log.Action("User exits through window exit")
 			ui.Quit()
 			return false
 		})


### PR DESCRIPTION
* Avoid file locking errors (Windows ) when removing server, especially VirtualBox log files - do not report errors to the user
* Fixed VirtualBox global settings path on Linux, Darwin
* Prevent closing VM by saving the status (tested on 5.x, 6.x)
* Clarify log file by adding tags (ACTION, WARNING, INFO, ERROR) which hopefully help in `grep` operations
* Give more user-friendly error message if the user enters wrong installation code